### PR TITLE
Fix that the options are being passed incorrectly

### DIFF
--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -38,7 +38,7 @@ defmodule Cluster.Strategy.Gossip do
   @default_multicast_addr {230,1,1,251}
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, [opts])
+    GenServer.start_link(__MODULE__, opts)
   end
 
   def init(opts) do


### PR DESCRIPTION
The options of the `Gossip` adapter were passed incorrectly to the GenServer.

So it crashed with the following error:
```
** (Mix) Could not start application libcluster: Cluster.App.start(:normal, []) returned an error: shutdown: failed to start child: Cluster.Strategy.Gossip
    ** (EXIT) an exception was raised:
        ** (KeyError) key :topology not found in: [[topology: :example, connect: {:net_kernel, :connect, []}, disconnect: {:net_kernel, :disconnect, []}, config: []]]
            (elixir) lib/keyword.ex:333: Keyword.fetch!/2
            (libcluster) lib/strategy/gossip.ex:46: Cluster.Strategy.Gossip.init/1
            (stdlib) gen_server.erl:328: :gen_server.init_it/6
            (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```